### PR TITLE
Fix some file/directory issues

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -97,8 +97,9 @@ impl Plugins {
             }
         }
 
-        let temp_filename = format!("{}init.zsh", std::env::temp_dir().display());
-        let mut temp_file = OpenOptions::new().write(true).create_new(true).open(&temp_filename).unwrap();
+        let filename = "init.zsh";
+        let temp_file_path = std::env::temp_dir().join(filename);
+        let mut temp_file = OpenOptions::new().write(true).create(true).truncate(true).open(&temp_file_path).expect("temp file");
 
         for plugin in &self.plugins {
             writeln!(temp_file, "{}", plugin)
@@ -107,7 +108,9 @@ impl Plugins {
         writeln!(temp_file, "autoload -Uz compinit; compinit -iCd $HOME/.zcompdump")
             .expect("Should be able to write the autoload line");
 
-        fs::rename(&temp_filename, &self.home.join("init.zsh")).unwrap();
+        let dst_file_path = &self.home.join(filename);
+        fs::copy(&temp_file_path, &dst_file_path).expect("Should be able to dst_file");
+        fs::remove_file(&temp_file_path).expect("Should be able to remove temp_file");
         Ok(())
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -189,7 +189,7 @@ impl Plugin {
         if ! path.is_dir() {
             let parent = path.parent().unwrap();
             if ! parent.exists() {
-                fs::create_dir(parent).map_err(Error::Io)?;
+                fs::create_dir_all(parent).map_err(Error::Io)?;
             }
 
             let url = format!("https://github.com/{}/{}", author, name);


### PR DESCRIPTION
Thanks for your awesome project, @jedahan! I've faced a several issues with `zr` trying to use it on my CentOS-7. And fixed them all. 😉 

1.  You shouldn't really use `format` or any other string-based operations for `path` concatenation. (On my linux `zr` tried to write `/tmpinit.zsh` file)
2. OpenOptions should be configured with `create(true).truncate(true)` in order to overwrite existing temp file.
3. `create_dir` fails if some of the parents doesn't exist (`~/.zr` for example).